### PR TITLE
Updates boot sequence files

### DIFF
--- a/boot/README.md
+++ b/boot/README.md
@@ -1,8 +1,8 @@
 # Boot Scripts
 
-This directory should be placed in the root directory of a flash drive which has a debian image dd'ed onto it. The files will be mounted automatically at `/lib/live/mount/medium/`. These scripts are responsible for downloading the test bench and latest binaries and beginning the testing sequence.
+This directory should be placed in the root directory of a flash drive which has a Debian image dd'ed onto it. The files will be mounted automatically at `/lib/live/mount/medium/`. These scripts are responsible for downloading the test bench and latest binaries and beginning the testing sequence.
 
 ## Contents
-* `config.sh` is file which simply sets the environment variable of the testalator port.
+* `host.js` contains structured data about where the test server lives and the identifier for this particular test runner. Ask another Tessel Team Member if you have questions about what these properties should be set to.
 * `tessel-session.sh` and `term.sh` are the meat and potatoes of downloading testing resources and initializing the tests.
 * `.ssh` is a folder with SSH keys and a valid `known_hosts` file to access the `testalator server`. They have been `.gitignore`d for security reasons so if you need them, please contact a Tessel Team Member.

--- a/boot/host.json
+++ b/boot/host.json
@@ -1,0 +1,9 @@
+{
+  "ssid" : "SSID_OF_TEST_ROUTER",
+  "password" : "PASSWORD_OF_TEST_ROUTER",
+  "name" : "UNIQUE_NAME",
+  "build": "DATE_OF_WHEN_WAS_THIS_UPDATED",
+  "server": "http://testalator.tessel.io",
+  "port": "PORT_NUM_ON_SERVER",
+  "pingIP":"192.168.0.1"
+}

--- a/boot/term.sh
+++ b/boot/term.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
 set -e
 
-SERVER=testalator.tessel.io
-# Import device specific settings like the port
-source /lib/live/mount/medium/config.sh
+# Save the path to our host json data
+HOST_PATH="/lib/live/mount/medium/host.json";
+# Parse the server url
+SERVER=$(node -pe 'JSON.parse(process.argv[1]).server' "$(cat "$HOST_PATH")")
+# Parse the port number
+PORT=$(node -pe 'JSON.parse(process.argv[1]).port' "$(cat "$HOST_PATH")")
 
 killall xscreensaver || true
 

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.env


### PR DESCRIPTION
- eliminates another boot shell script (`config.sh`)
- moved the PORT setting into `host.js`
- mentions the role `host.js` plays in README
- imports settings from `host.js` into `term.sh` rather than repeating the information
