### PR TITLE
Update to point and revision 0.0.11 of the CLI

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -9,7 +9,7 @@
     "mongojs": "~0.18.2",
     "request": "^2.57.0",
     "socket.io": "~0.9.14",
-    "t2": "git://github.com/tessel/t2-cli.git#jon-rig-improvements",
+    "t2-cli": "0.0.11",
     "url-join": "0.0.1",
     "usb": "^1.0.6"
   },


### PR DESCRIPTION
Dependent on merging https://github.com/tessel/t2-cli/pull/555 (or whatever PRs that splits into) and release of the next version (0.0.11).
