### PR TITLE
Removes additional config file in favor of using host.json example

### DIFF
--- a/client/config.json
+++ b/client/config.json
@@ -1,3 +1,3 @@
 {
-  "hostPath": "./hostConfigs/usbConfig.json"
+  "devPath": "../boot/host.json"
 }

--- a/client/hostConfigs/usbConfig.json
+++ b/client/hostConfigs/usbConfig.json
@@ -1,9 +1,0 @@
-{
-  "name": "host1",
-  "vpn": "????",
-  "server": "http://testalator.tessel.io/",
-  "build": "2c2043a883f19bea393e93c3313542e7297972af",
-  "ssid" : "XXXX",
-  "password" : "XXXX",
-  "pingIP" : "192.168.8.102"
-}

--- a/client/index.js
+++ b/client/index.js
@@ -24,7 +24,7 @@ if (fs.existsSync(liveHostPath)){
   configs.host = require(liveHostPath);
 } else {
   // otherwise default host configs
-  configs.host = require(path.join(__dirname, configs.hostPath));
+  configs.host = require(path.join(__dirname, configs.devPath));
 }
 configs.tests = require(path.join(__dirname, '../config.json')).tests;
 console.log("HOST IS", configs.host);


### PR DESCRIPTION
The testalator client either loads server/test info from a file that exists only in a unique path (`/lib/live/mount/medium/host.json`) on the testing debian machines or loads it from a path in the client directory (`/hostConfigs/usbConfig.json`). Now that we have an example `host.json` in the `/boot` path, it makes sense to consolidate these two functions. 

This PR removes the old alternative JSON file in favor of searching in the example `host.json` path.

The fewer config files the better.
