### PR TITLE
Adds ignore file for binary info

### DIFF
--- a/client/.gitignore
+++ b/client/.gitignore
@@ -1,0 +1,2 @@
+bin/
+build.json


### PR DESCRIPTION
The binaries and builds.json file is downloaded each time the client has run if the files don't exist or don't match what's on our build server. It annoys me to seem them listed as untracked by git.
