### PR TITLE
Launch browser when client finishes initializing

### DIFF
--- a/boot/tessel-session.sh
+++ b/boot/tessel-session.sh
@@ -1,6 +1,25 @@
 #!/bin/bash
 set -e
 
-xfce4-terminal --hold -e "bash -x /lib/live/mount/medium/term.sh"
+# The port that the client will run at
+PORT=3000
+# The address of the client
+CLIENT_URL="localhost:"$PORT
+
+# Download and initialize the client in the background
+xfce4-terminal --hold -e "bash -x /lib/live/mount/medium/term.sh" &
+
+# Wait for the client to finish initializing before continuing
+while [ `curl --write-out %{http_code} --silent --output /dev/null $CLIENT_URL` -ne 200 ]
+do
+  # The client is not returning a 200 status code
+  echo "Client is not initialized yet. Waiting..."
+  # Continue sleeping
+  sleep 2
+done
+
+# The client is finally up, open the browser
 xdg-open http://localhost:3000
 
+# Wait infinitely so that we don't close the client 
+wait;


### PR DESCRIPTION
This doesn't work yet because it seems like the `tessel-session.sh` script is exited before it even gets to the wait loop.

Also, `curl` isn't currently installed as a package.
