### PR TITLE
relative paths to files

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -276,7 +276,7 @@ rig_usb.on('attach', function(dev){
     dev.unitUnderTest = null;
     dev.data = [];
 
-    var ps = child_process.spawn('python', ['-u', 'tests/tests.py', dev.serialNumber])
+    var ps = child_process.spawn('python', ['-u', path.join(__dirname, 'tests/tests.py'), dev.serialNumber])
 
     function parseData(data){
       // console.log("parseData", data);

--- a/client/index.js
+++ b/client/index.js
@@ -47,8 +47,7 @@ var isDownloading = false;
 var app = express();
 var http = require('http');
 var server = http.createServer(app);
-
-var verifyFile = fs.readFileSync('./tests/resources/deadbeef.hex');
+var verifyFile = fs.readFileSync(path.join(__dirname, 'tests/resources/deadbeef.hex'));
 var USB_OPTS = {bytes:84, verify: verifyFile}
 var ETH_OPTS = {host: configs.host.pingIP}
 var WIFI_OPTS = {'ssid': configs.host.ssid,


### PR DESCRIPTION
This allows us to run the client's `index.js` from anywhere in the repo. Otherwise you would get this error:

```
fs.js:549
  return binding.open(pathModule._makeLong(path), stringToFlags(flags), mode);
                                                  ^

Error: ENOENT: no such file or directory, open './tests/resources/deadbeef.hex'
    at Error (native)
    at Object.fs.openSync (fs.js:549:18)
    at Object.fs.readFileSync (fs.js:397:15)
    at Object.<anonymous> (/Users/Jon/Work/technical/t2-test-rig-sw/client/index.js:51:21)
    at Module._compile (module.js:435:26)
    at Object.Module._extensions..js (module.js:442:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:311:12)
    at Function.Module.runMain (module.js:467:10)
    at startup (node.js:134:18)
```
